### PR TITLE
Added support for the onColor and offColor properties.

### DIFF
--- a/addon/components/bs-switch.js
+++ b/addon/components/bs-switch.js
@@ -9,6 +9,8 @@ var bsSwitchComponent = Ember.Component.extend({
   btnSize: 'small',
   name: 'bs-switch',
   disabled: false,
+  onColor: 'primary',  // 'primary', 'info', 'success', 'warning', 'danger', 'default'
+  offColor: 'default', // 'primary', 'info', 'success', 'warning', 'danger', 'default'
   onText: 'ON',
   offText: 'OFF',
   labelText: '',
@@ -34,6 +36,8 @@ var bsSwitchComponent = Ember.Component.extend({
       "disabled": this.get('disabled'),
       "onText": this.get('onText'),
       "offText": this.get('offText'),
+      "onColor": this.get('onColor'),
+      "offColor": this.get('offColor'),
       "labelText": this.get('labelText')
     });
 


### PR DESCRIPTION
This change allow to customize the switch's look and feel.
It is possible to use the default bootstrap colors  ( 'primary', 'info', 'success', 'warning', 'danger', 'default') to personalize the ON and OFF buttons color.

Code example:
```
        {{bs-switch name="activeSearch"
            btnSize="normal"
            onText="Yes"
            offText="No"
            onColor='success'
            offColor='warning'
            status=filterActive}}
```